### PR TITLE
Fix broken links for MelonExchange and Cryptocompare on portalNew

### DIFF
--- a/imports/ui/components/portal/portalNew.html
+++ b/imports/ui/components/portal/portalNew.html
@@ -55,7 +55,7 @@
                     <div class="setup-module">
                       <h6 style="color:grey">Exchange Module:</h6>
                       <ul class="setup-module-list">
-                        <li><a href="https://daemon.melonport.com/liquidityprovider" target="_blank">Melon Exchange</a></li>
+                        <li><a href="https://kovan.etherscan.io/address/{{exchange}} " target="_blank">Melon Exchange</a></li>
                       </ul>
                     </div>
                   </div>
@@ -65,7 +65,7 @@
                     <div class="setup-module">
                       <h6 style="color:grey">Price Feed Module:</h6>
                       <ul class="setup-module-list">
-                        <li><a href="https://daemon.melonport.com/oracle" target="_blank">Cryptocompare</a></li>
+                        <li><a href="https://kovan.etherscan.io/address/{{cryptoCompare}}" target="_blank">Cryptocompare</a></li>
                       </ul>
                     </div>
                   </div>


### PR DESCRIPTION
Issue reference: https://github.com/melonproject/portal/issues/244

Both addresses were already available from adressList.js they were just not referenced correctly. 