### PR TITLE
Summaries state

### DIFF
--- a/imports/redux/summary.js
+++ b/imports/redux/summary.js
@@ -67,13 +67,6 @@ export const middleware = store => next => (action) => {
         }
         informations.ranking = `${ranking} out of ${numberOfVaults}`;
         performCalculations(vault.address).then((calculations) => {
-          // const serializedCalculations = Object.keys(calculations).reduce(
-          //   (accumulator, currentKey) => ({
-          //     ...accumulator,
-          //     [currentKey]: calculations[currentKey].toString(),
-          //   }),
-          //   {},
-          // );
           informations.sharePrice = calculations.sharePrice.toString();
           store.dispatch(creators.updateInformations(informations));
         });

--- a/imports/redux/summary.js
+++ b/imports/redux/summary.js
@@ -1,0 +1,96 @@
+import { Meteor } from 'meteor/meteor';
+import Vaults from '/imports/api/vaults';
+import performCalculations from '/imports/melon/interface/performCalculations';
+
+export const initialState = {
+  ranking: undefined,
+  fundName: undefined,
+  fundAddress: undefined,
+  sharePrice: undefined,
+};
+
+export const types = {
+  REQUEST_INFORMATIONS: 'REQUEST_INFORMATIONS:summary:portal.melonport.com',
+  UPDATE_INFORMATIONS: 'UPDATE_INFORMATIONS:summary:portal.melonport.com',
+};
+
+export const creators = {
+  requestInformations: managerAddress => ({
+    type: types.REQUEST_INFORMATIONS,
+    managerAddress,
+  }),
+  updateInformations: informations => ({
+    type: types.UPDATE_INFORMATIONS,
+    ...informations,
+  }),
+};
+
+export const reducer = (state = initialState, action) => {
+  const { type, ...params } = action;
+  switch (type) {
+    case types.REQUEST_INFORMATIONS: {
+      return state;
+    }
+    case types.UPDATE_INFORMATIONS: {
+      return {
+        ...state,
+        ...params,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export const middleware = store => next => (action) => {
+  const { type, ...params } = action;
+
+  switch (type) {
+    case types.REQUEST_INFORMATIONS: {
+      const vault = Vaults.findOne({ owner: params.managerAddress });
+      const informations = {};
+      if (vault) {
+        informations.fundName = vault.name;
+        informations.fundAddress = vault.address;
+
+        const numberOfVaults = Vaults.find().count();
+        const sortedVaults = Vaults.find(
+          {},
+          { sort: { sharePrice: -1, createdAt: -1 } },
+        ).fetch();
+        let ranking;
+        for (let i = 0; i < sortedVaults.length; i++) {
+          if (vault.address == sortedVaults[i].address) {
+            ranking = i + 1;
+            break;
+          }
+        }
+        informations.ranking = `${ranking} out of ${numberOfVaults}`;
+        performCalculations(vault.address).then((calculations) => {
+          // const serializedCalculations = Object.keys(calculations).reduce(
+          //   (accumulator, currentKey) => ({
+          //     ...accumulator,
+          //     [currentKey]: calculations[currentKey].toString(),
+          //   }),
+          //   {},
+          // );
+          informations.sharePrice = calculations.sharePrice.toString();
+          store.dispatch(creators.updateInformations(informations));
+        });
+      } else {
+        console.warn('REQUEST_INFORMARTIONS failed, no vault found for this manager',
+          params.managerAddress,
+        );
+      }
+      break;
+    }
+
+    case types.UPDATE_INFORMATIONS: {
+      break;
+    }
+    default:
+  }
+  return next(action);
+};
+
+export default reducer;

--- a/imports/startup/client/store.js
+++ b/imports/startup/client/store.js
@@ -13,6 +13,11 @@ import web3 from '/imports/redux/web3';
 import user from '/imports/redux/user';
 import userMiddleware from '/imports/redux/middlewares/user';
 import Raven from '/imports/startup/utils/raven';
+import {
+  default as summary,
+  middleware as summaryMiddleware,
+} from '/imports/redux/summary';
+
 
 export default createStore(
   combineReducers({
@@ -20,6 +25,7 @@ export default createStore(
     web3,
     vault,
     user,
+    summary,
   }),
   {
     /* preloadedState */
@@ -30,6 +36,7 @@ export default createStore(
       vaultMiddleware,
       userMiddleware,
       createRavenMiddleware(Raven),
+      summaryMiddleware,
     ),
     /* eslint-disable no-underscore-dangle */
     window.__REDUX_DEVTOOLS_EXTENSION__

--- a/imports/ui/components/portal/portalList.html
+++ b/imports/ui/components/portal/portalList.html
@@ -11,6 +11,9 @@
                   <table id="table-portal-overview" class="table table-bordered table-hover mp-daemon-table mp-daemon-table-data mp-portal-table"
                     style="width:100%;">
                     <tr>
+                      <th style="width:25%">Ranking
+                        <p>Ranking</p>
+                      </th>
                       <th style="width:25%">Manager
                         <p>(Identicon)</p>
                       </th>
@@ -39,6 +42,11 @@
                       <tbody>
                         {{#each searchedVaults}}
                         <tr>
+                          <td class="ranking">
+                            <a class="table-link" target="_blank" rel="noopener">
+                                {{getRanking @index}}
+                              </a>
+                          </td>
                           <td class="identicon">
                             <a class="table-link" href="https://kovan.etherscan.io/address/{{owner}}" target="_blank" rel="noopener">
                                 {{> dapp_identicon identity=owner class="dapp-small"}}

--- a/imports/ui/components/portal/portalList.js
+++ b/imports/ui/components/portal/portalList.js
@@ -50,6 +50,7 @@ Template.portalList.helpers({
     Template.instance().data.main() === 'visit'
       ? `/visit/${address}`
       : `/fund/${address}`,
+  getRanking: (index) => index + 1,
 });
 
 Template.portalList.onRendered(() => { });

--- a/imports/ui/components/summary/executiveSummary.html
+++ b/imports/ui/components/summary/executiveSummary.html
@@ -22,7 +22,7 @@
       <p class="status">Fund</p>
       {{#if hasManagerCreatedVault}}
       <p class="value">
-        <a href="/fund/{{getManagerAddressOfVault}}" class="truncate green-text text-lighten-2">{{getManagerNameOfVault}}</a>
+        <a href="/fund/{{getManagerAddressOfVault}}" class="truncate green-text text-lighten-2">{{getFundName}}</a>
       </p>
       {{else}} {{#if selectedAccount}}
       <p class="value">

--- a/imports/ui/components/summary/executiveSummary.js
+++ b/imports/ui/components/summary/executiveSummary.js
@@ -13,11 +13,13 @@ Template.executiveSummary.onCreated(() => {
   const template = Template.instance();
   Meteor.subscribe('vaults');
   template.sharePrice = new ReactiveVar(0);
+  template.fundName = new ReactiveVar('');
   store.subscribe(() => {
     const currentState = store.getState().summary;
     template.sharePrice.set(
       new BigNumber(currentState.sharePrice || 0).toString(),
     );
+    template.fundName.set(currentState.fundName);
   });
   if (FlowRouter.getParam('address')) {
     store.dispatch(
@@ -31,6 +33,9 @@ Template.executiveSummary.helpers({
     const template = Template.instance();
     const finneySharePrice = (template.sharePrice.get() * 1000).toFixed(1);
     return finneySharePrice;
+  },
+  getFundName() {
+    return Template.instance().fundName.get();
   },
 });
 

--- a/imports/ui/components/summary/executiveSummary.js
+++ b/imports/ui/components/summary/executiveSummary.js
@@ -4,7 +4,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import BigNumber from 'bignumber.js';
 
 import store from '/imports/startup/client/store';
-import { creators } from '/imports/redux/vault';
+import { creators } from '/imports/redux/summary';
 
 // Corresponding html file
 import './executiveSummary.html';
@@ -14,14 +14,14 @@ Template.executiveSummary.onCreated(() => {
   Meteor.subscribe('vaults');
   template.sharePrice = new ReactiveVar(0);
   store.subscribe(() => {
-    const currentState = store.getState().vault;
+    const currentState = store.getState().summary;
     template.sharePrice.set(
       new BigNumber(currentState.sharePrice || 0).toString(),
     );
   });
   if (FlowRouter.getParam('address')) {
     store.dispatch(
-      creators.requestCalculations(FlowRouter.getParam('address')),
+      creators.requestInformations(Session.get('selectedAccount')),
     );
   }
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jest:watch": "jest --watch",
     "pretest": "npm run lint --silent",
     "testrpc": "testrpc",
-    "deploy:web": "DEPLOY_HOSTNAME=eu-west-1.galaxy-deploy.meteor.com meteor deploy 0.2.0.web.deploys.melon.network --owner melonproject --settings ./settings/web.json",
+    "deploy:web": "DEPLOY_HOSTNAME=eu-west-1.galaxy-deploy.meteor.com meteor deploy 0.2.0.web.deploys.melon.network --owner melonproject --settings ./settings/0.2.2-web.json",
     "test:chimp:watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests",
     "test:chimp:once": "chimp --ddp=http://localhost:3000 --mocha --path=tests",
     "format": "prettier-eslint --write \"imports/**/*.js\"",
@@ -25,11 +25,20 @@
     },
     "extends": "@meteorjs/eslint-config-meteor",
     "rules": {
-      "max-len": ["error", 80, 2]
+      "max-len": [
+        "error",
+        80,
+        2
+      ]
     }
   },
   "babel": {
-    "presets": ["flow", "meteor", "es2015", "react"]
+    "presets": [
+      "flow",
+      "meteor",
+      "es2015",
+      "react"
+    ]
   },
   "dependencies": {
     "@melonproject/protocol": "0.2.0-alpha.17",


### PR DESCRIPTION
This branch solves the inconsistency bug in Melon/executive summary, where share price sometimes  was the share price of the user's fund, and sometimes was the share price of the fund whose page was last seen. Users expressed a preference for having their info only in Melon/executive summary, so we have now a new state that exclusively provide informations relative to the user's fund.